### PR TITLE
Fix ignored whitespaces and line breaks in fenced code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix ignored whitespaces and line breaks in fenced code ([#4](https://github.com/marp-team/marp-react/issues/4), [#5](https://github.com/marp-team/marp-react/pull/5))
+
 ## v0.0.2 - 2019-03-03
 
 ### Changed

--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -33,5 +33,8 @@ const html = htm.bind((type: string, props, ...children) => {
 })
 
 export default function parse(htmlStr: string) {
-  return html([htmlStr])
+  const lines = htmlStr.split('\n')
+  const breaks = [...Array(lines.length - 1)].map(() => '\n')
+
+  return html(lines, ...breaks)
 }

--- a/test/index.tsx
+++ b/test/index.tsx
@@ -185,7 +185,7 @@ describe('MarpWorker', () => {
     act(() => {
       worker.interrupt(false)
     })
-    expect(marp.text()).toBe('3')
+    expect(marp.text().trim()).toBe('3')
 
     // 2nd rendering will be skipped
     expect(worker.postQueue).not.toBeCalledWith(expect.arrayContaining(['2']))

--- a/test/index.tsx
+++ b/test/index.tsx
@@ -39,6 +39,27 @@ class: lead
     expect(marp.find('figure')).toHaveLength(1)
   })
 
+  it('renders highlighted fence correctly', () => {
+    const markdown = `
+\`\`\`js
+test({
+  foo: 0,
+  bar: 1,
+});
+\`\`\`
+`.trim()
+
+    const marp = mount(<Marp markdown={markdown} />)
+    expect(marp.text().trim()).toBe(
+      `
+test({
+  foo: 0,
+  bar: 1,
+});
+`.trim()
+    )
+  })
+
   it('injects global style for rendering Marp slide', () => {
     mount(<Marp />)
     expect(document.head.querySelector('style[id^="marp-style"]')).toBeTruthy()


### PR DESCRIPTION
It resolves #4.

As like as HTML, JSX converts line breaks to single whitespace. It would bring collapsed whitespaces / line breaks at around highlighted element of code block.

Luckily, we can deal it with using JS expression. This update will convert line breaks in the rendered HTML into JS expression before applying to [`htm`](https://github.com/developit/htm).

In short, it means converting [HTM](https://github.com/developit/htm):

```javascript
htm`
  <pre>
    test({
      foo: 0;
      bar: 0;
    })
  </pre>
`
```

to

```javascript
htm`
  <pre>${'\n'}
    test({${'\n'}
      foo: 0;${'\n'}
      bar: 0;${'\n'}
    })${'\n'}
  </pre>
`
```
