### PR TITLE
Emit declarations to lib directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@
 
 - Add `init` prop to `<Marp>` component for using plugins for Marp ([#17](https://github.com/marp-team/marp-react/issues/17), [#20](https://github.com/marp-team/marp-react/pull/20) by [@exKAZUu](https://github.com/exKAZUu))
 
-### Changed
+### Fixed
 
 - Allow multiple `<MarpWorker>` components ([#7](https://github.com/marp-team/marp-react/issues/7), [#8](https://github.com/marp-team/marp-react/pull/8))
+- Emit declarations into `lib` directory to work type definition for partial scripts ([#21](https://github.com/marp-team/marp-react/issues/21), [#26](https://github.com/marp-team/marp-react/pull/26))
+
+### Changed
+
 - Upgrade Node v10.16.3 ([#16](https://github.com/marp-team/marp-react/pull/16))
 - Upgrade dependent packages to the latest version ([#9](https://github.com/marp-team/marp-react/pull/9), [#11](https://github.com/marp-team/marp-react/pull/11), [#16](https://github.com/marp-team/marp-react/pull/16), [#22](https://github.com/marp-team/marp-react/pull/22) by [@exKAZUu](https://github.com/exKAZUu))
 

--- a/package.json
+++ b/package.json
@@ -20,15 +20,14 @@
   "main": "lib/index.js",
   "module": "module/index.js",
   "sideEffects": false,
-  "types": "types/index.d.ts",
+  "types": "lib/index.d.ts",
   "files": [
     "dist/",
     "lib/",
-    "module/",
-    "types/"
+    "module/"
   ],
   "scripts": {
-    "build:cjs": "rimraf lib && tsc --module commonjs --outDir lib",
+    "build:cjs": "rimraf lib && tsc --declaration --module commonjs --outDir lib",
     "build:module": "rimraf module && tsc --module esnext --outDir module",
     "build:worker": "rimraf dist && webpack --mode production",
     "check:audit": "yarn audit",
@@ -37,12 +36,11 @@
     "format": "prettier \"**/*.{css,js,json,jsx,md,scss,ts,tsx,yaml,yml}\"",
     "format:write": "yarn -s format --write",
     "lint:js": "eslint \"**/*.{js,jsx,ts,tsx}\"",
-    "prepack": "npm-run-all --parallel check:* lint:* test:coverage --parallel build:* types",
+    "prepack": "npm-run-all --parallel check:* lint:* test:coverage --parallel build:*",
     "preversion": "run-p check:* lint:* test:coverage",
     "storybook": "start-storybook -p 6006",
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "types": "rimraf types && tsc --declaration --emitDeclarationOnly --outDir types",
     "version": "curl https://raw.githubusercontent.com/marp-team/marp/master/version.js | node && git add -A CHANGELOG.md"
   },
   "dependencies": {


### PR DESCRIPTION
Stop splitting out emitting type definitions into `types` directory, and emit declarations into the same directory as `lib`.

Resolve #21, and recover #25. `@marp-team/marp-react/lib/worker` will reference correct typing.